### PR TITLE
feat(testing): implement testing roadmap sections 0-2

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,14 @@
+[run]
+source = src/pydapter
+omit = 
+    tests/*
+    .github/khive_modes.json
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    raise NotImplementedError
+    if __name__ == .__main__.:
+    pass
+    raise ImportError

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to pydapter
+
+Thank you for your interest in contributing to pydapter! This document provides guidelines and instructions for contributing to this project.
+
+## Code of Conduct
+
+Please be respectful and considerate of others when contributing to this project.
+
+## How to Contribute
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add some amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+## Development Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/ohdearquant/pydapter.git
+cd pydapter
+
+# Install development dependencies
+pip install -e ".[all,dev]"
+
+# Run tests
+pytest
+```
+
+## Automated Roles
+
+This project uses automated roles via the khive system. The role definitions are stored in `.github/khive_modes.json`. The khive-orchestrator opens tasks and PRs, and coordinates work between different specialized roles:
+
+- **Orchestrator**: Coordinates tasks and manages the project workflow
+- **Architect**: Designs the technical architecture
+- **Researcher**: Conducts research and gathers information
+- **Implementer**: Implements code based on specifications
+- **Quality Reviewer**: Reviews code for quality and correctness
+- **Documenter**: Creates and maintains documentation
+
+## Pull Request Process
+
+1. Ensure your code follows the project's coding standards
+2. Update the README.md or documentation with details of changes if appropriate
+3. The PR will be merged once it receives approval from maintainers
+
+## Testing
+
+Please ensure that your contributions include appropriate tests and maintain or improve the current test coverage.
+
+## License
+
+By contributing to pydapter, you agree that your contributions will be licensed under the project's license.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,22 +34,32 @@ neo4j     = ["neo4j>=5.19"]
 motor     = ["motor>=3"]
 qdrant    = ["qdrant-client>=1.14"]
 aiohttp   = ["aiohttp>=3.11.10"]
+test      = [
+    "pytest>=8.3.5",
+    "pytest-asyncio>=0.26.0",
+    "pytest-cov>=4.1.0",
+    "pytest-benchmark>=4.0.0",
+    "testcontainers[postgres,qdrant]>=3.7.0"
+]
 
 # ----------------------------------
 all = [
-    "pandas",
-    "excel",
-    "sql",
-    "postgres",
-    "mongo",
-    "weaviate",
-    "neo4j",
-    "asyncpg",
-    "motor",
-    "qdrant-client",
-    "aiohttp"
+    "pandas>=2.2",
+    "xlsxwriter>=3.2",
+    "sqlalchemy>=2.0",
+    "psycopg[binary]>=3",
+    "asyncpg>=0.29",
+    "pymongo>=4.7",
+    "weaviate-client>=4.4",
+    "neo4j>=5.19",
+    "motor>=3",
+    "qdrant-client>=1.14",
+    "aiohttp>=3.11.10"
 ]
 
+[tool.pytest.ini_options]
+addopts = "-ra --cov=pydapter --cov-report=term-missing"
+testpaths = ["tests"]
 
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+import pytest
+import uuid
+import tempfile
+from pydapter import Adaptable
+from pydapter.adapters import JsonAdapter, CsvAdapter, TomlAdapter
+
+
+class _ModelFactory:
+    def __call__(self, **kw):
+        from pydantic import BaseModel
+
+        class M(Adaptable, BaseModel):
+            id: int
+            name: str
+            value: float
+
+        M.register_adapter(JsonAdapter)
+        M.register_adapter(CsvAdapter)
+        M.register_adapter(TomlAdapter)
+        return M(**kw)
+
+
+@pytest.fixture
+def sample(_ModelFactory):  # pylint: disable=invalid-name
+    return _ModelFactory(id=1, name="foo", value=42.5)
+
+
+@pytest.fixture(scope="session")
+def pg_url():
+    from testcontainers.postgres import PostgresContainer
+
+    with PostgresContainer("postgres:16-alpine") as pg:
+        yield pg.get_connection_url()  # postgresql://user:pass@host:port/db
+
+
+@pytest.fixture(scope="session")
+def qdrant_url():
+    from testcontainers.qdrant import QdrantContainer
+
+    with QdrantContainer("qdrant/qdrant:v1.8.1") as qc:
+        yield f"http://{qc.get_container_host_ip()}:{qc.get_exposed_port(6333)}"

--- a/tests/test_core_adapters.py
+++ b/tests/test_core_adapters.py
@@ -1,0 +1,13 @@
+import pytest
+import json
+import toml
+import csv
+import io
+from pydapter.adapters import JsonAdapter, CsvAdapter, TomlAdapter
+
+
+@pytest.mark.parametrize("adapter_key", ["json", "toml", "csv"])
+def test_text_roundtrip(sample, adapter_key):
+    dumped = sample.adapt_to(obj_key=adapter_key)
+    restored = sample.__class__.adapt_from(dumped, obj_key=adapter_key)
+    assert restored == sample


### PR DESCRIPTION
This PR implements sections 0, 1, and 2 of the testing roadmap defined in Issue #2.

## Changes
- Add CONTRIBUTING.md with project guidelines and automated roles
- Add .coveragerc to exclude tests and generated files
- Update pyproject.toml with test dependencies and pytest config
- Set up test harness with fixtures for sync and async testing
- Implement core round-trip tests for adapters

Closes #2 (partially - sections 0-2 only)