### PR TITLE
docs: add CI and coverage badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # pydapter
 
+[![CI](https://github.com/ohdearquant/pydapter/actions/workflows/ci.yml/badge.svg)](https://github.com/ohdearquant/pydapter/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/ohdearquant/pydapter/branch/main/graph/badge.svg)](https://codecov.io/gh/ohdearquant/pydapter)
+
 **pydapter** is a micro-library that lets any Pydantic model become _adaptable_
 to / from arbitrary external representations (JSON, CSV, vector stores,
 databases …).


### PR DESCRIPTION
Implements section 7 of the testing roadmap from Issue #2. Added CI and coverage badges to README.md and verified the quick-start code snippet is accurate with the latest implementation. Closes #2.