### PR TITLE
fix(ci): add virtual environment for uv pip install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,16 @@ jobs:
         with:
           python-version: '${{ matrix.py }}'
       - run: pip install uv
-      - run: |
+      - name: Create and activate virtual environment
+        run: |
+          uv venv .venv
+          echo "VIRTUAL_ENV=$GITHUB_WORKSPACE/.venv" >> $GITHUB_ENV
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
+      - name: Install dependencies
+        run: |
           uv pip install -e ".[$([[ ${{ matrix.extras }} == all ]] && echo all || echo test)]"
-      - run: pytest -q --cov=pydapter --cov-report=xml
+      - name: Run tests
+        run: pytest -q --cov=pydapter --cov-report=xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
This PR fixes the CI workflow by creating and activating a virtual environment before running uv pip install. The fix ensures that uv pip install runs within an activated virtual environment, which is required by uv.

## Changes
- Added a step to create a virtual environment using 
- Set up environment variables to properly activate the virtual environment in GitHub Actions
- Added descriptive step names for better readability and debugging

Fixes #2