### PR TITLE
Feat/update protocols

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name            = "pydapter"
-version         = "0.2.1"
+version         = "0.2.2"
 description     = "Tiny trait + adapter toolkit for pydantic models"
 readme          = "README.md"
 requires-python = ">=3.10"

--- a/src/pydapter/__init__.py
+++ b/src/pydapter/__init__.py
@@ -33,4 +33,4 @@ __all__ = (
     "as_event",
 )
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/src/pydapter/protocols/base_model.py
+++ b/src/pydapter/protocols/base_model.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel, ConfigDict, field_serializer
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+# Export configured BaseModel for tests and direct use
+class BasePydapterModel(BaseModel):
+    """Base model with standard configuration"""
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        use_enum_values=True,
+        extra="forbid",
+    )

--- a/src/pydapter/protocols/base_model.py
+++ b/src/pydapter/protocols/base_model.py
@@ -1,7 +1,5 @@
-from pydantic import BaseModel, ConfigDict, field_serializer
-from datetime import datetime
-from typing import Any
-from uuid import UUID
+from pydantic import BaseModel, ConfigDict
+
 
 # Export configured BaseModel for tests and direct use
 class BasePydapterModel(BaseModel):

--- a/src/pydapter/protocols/cryptographical.py
+++ b/src/pydapter/protocols/cryptographical.py
@@ -1,4 +1,4 @@
-from typing import Protocol, Union, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, Union, runtime_checkable
 
 from pydantic import JsonValue
 
@@ -12,6 +12,10 @@ class Cryptographical(Protocol):
 
 
 class CryptographicalMixin:
+    if TYPE_CHECKING:
+        content: JsonValue
+        sha256: str | None
+
     def hash_content(self) -> None:
         if self.content is None:
             raise ValueError("Content is not set.")

--- a/src/pydapter/protocols/embeddable.py
+++ b/src/pydapter/protocols/embeddable.py
@@ -18,6 +18,7 @@ class EmbeddableMixin:
     """Mixin class for embedding functionality."""
 
     if TYPE_CHECKING:
+        content: str | None
         embedding: Embedding
 
     @property

--- a/src/pydapter/protocols/invokable.py
+++ b/src/pydapter/protocols/invokable.py
@@ -3,16 +3,12 @@ from asyncio.log import logger
 from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
-from uuid import UUID
 
 from pydantic import PrivateAttr
 
 from pydapter.fields.execution import Execution, ExecutionStatus
 
 from .utils import validate_model_to_dict
-
-if TYPE_CHECKING:
-    pass
 
 
 @runtime_checkable
@@ -34,8 +30,8 @@ class InvokableMixin:
     _handler_kwargs: dict[str, Any] = PrivateAttr({})
 
     if TYPE_CHECKING:
+        request: dict | None
         execution: Execution
-        id: UUID
 
     @property
     def has_invoked(self) -> bool:

--- a/src/pydapter/protocols/temporal.py
+++ b/src/pydapter/protocols/temporal.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from pydantic import field_serializer
 
@@ -16,6 +16,10 @@ class Temporal(Protocol):
 
 
 class TemporalMixin:
+    if TYPE_CHECKING:
+        created_at: datetime
+        updated_at: datetime
+
     def update_timestamp(self) -> None:
         """Update the last updated timestamp to the current time."""
         self.updated_at = datetime.now(timezone.utc)

--- a/tests/test_fields/test_field_core.py
+++ b/tests/test_fields/test_field_core.py
@@ -443,11 +443,12 @@ class TestModelCreation:
 
     def test_create_basic_model(self):
         """Test creating a simple model from fields"""
-        fields = [
-            Field(name="id", annotation=UUID, default_factory=uuid4),
-            Field(name="name", annotation=str),
-            Field(name="age", annotation=int, default=0),
-        ]
+
+        fields = {
+            "id": ID_FROZEN,
+            "name": Field(name="name", annotation=str),
+            "age": Field(name="age", annotation=int, default=0),
+        }
 
         Model = create_model("TestModel", fields=fields)
 
@@ -465,7 +466,9 @@ class TestModelCreation:
                 raise ValueError("Must be positive")
             return v
 
-        fields = [Field(name="count", annotation=int, validator=validate_positive)]
+        fields = {
+            "count": Field(name="count", annotation=int, validator=validate_positive),
+        }
 
         Model = create_model("TestModel", fields=fields)
 

--- a/uv.lock
+++ b/uv.lock
@@ -2576,7 +2576,7 @@ wheels = [
 
 [[package]]
 name = "pydapter"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "orjson" },


### PR DESCRIPTION
In this pr, we 
- introduced kwargs options to `Field.as_nullable`, and `Field.as_listable`
- Added the option to use dict in `create_model`, now will auto change field name when input a dict. 

```python
fields = {"id123" : ID_FROZEN}
User = create_model("User", fields=fields)

User.id   # wrong, name already overwritten
User.id123   # correct
```

