### PR TITLE
chore: Bump version to 0.3.1 in project files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name            = "pydapter"
-version         = "0.3.0"
+version         = "0.3.1"
 description     = "Tiny trait + adapter toolkit for pydantic models"
 readme          = "README.md"
 requires-python = ">=3.10"

--- a/src/pydapter/__init__.py
+++ b/src/pydapter/__init__.py
@@ -33,4 +33,4 @@ __all__ = (
     "as_event",
 )
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/src/pydapter/fields/builder.py
+++ b/src/pydapter/fields/builder.py
@@ -199,8 +199,8 @@ class DomainModelBuilder:
                 f"Add at least one field or field family before building."
             )
 
-        # Create field dictionary
-        fields = create_field_dict(self._fields)
+        # Create field dictionary - unpack the single dict as keyword arguments
+        fields = create_field_dict(**self._fields)
 
         # Merge model configuration
         config = {**self.model_config, **extra_config}

--- a/uv.lock
+++ b/uv.lock
@@ -2589,7 +2589,7 @@ wheels = [
 
 [[package]]
 name = "pydapter"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "orjson" },


### PR DESCRIPTION

  • Fix DomainModelBuilder to properly preserve field defaults and nullable settings
  • Change create_field_dict() call to use keyword argument unpacking

  Details

  The DomainModelBuilder.build() method was incorrectly passing fields to create_field_dict() as a single
  positional argument, causing field metadata (defaults, nullable settings) to be lost. This prevented
  model instances from being created with only required fields.

  Changed line 203 in builder.py from:
  `fields = create_field_dict(self._fields)`
  to:
  `fields = create_field_dict(**self._fields)`

  This ensures fields retain their configured defaults (e.g., is_deleted=False, version=1) and nullable
  settings (e.g., created_by=None, deleted_at=None).
