### PR TITLE
fix: 2 CRITICAL + 5 HIGH audit findings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,11 +99,13 @@ pgvector = [
 
 mongo = [
     "pymongo>=4.10",
+    "pydapter[motor]",
 ]
 
 weaviate = [
     "weaviate-client>=4.10",
     "weaviate>=0.1.2",
+    "pydapter[aiohttp]",
 ]
 
 neo4j = [
@@ -116,6 +118,7 @@ motor = [
 
 qdrant = [
     "qdrant-client>=1.10",
+    "grpcio>=1.60",
 ]
 
 redis = [

--- a/src/pydapter/core.py
+++ b/src/pydapter/core.py
@@ -20,7 +20,7 @@ from .exceptions import (
 from .exceptions import ValidationError as AdapterValidationError
 from .types import _redact_url
 
-T = TypeVar("T", contravariant=True)
+T = TypeVar("T")
 
 
 # ---------------------------------------------------------------- Dispatcher

--- a/src/pydapter/extras/async_sql_.py
+++ b/src/pydapter/extras/async_sql_.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from typing import Any, Literal, TypeVar
 
-from typing_extensions import NotRequired, Required, TypedDict
+from typing_extensions import NotRequired, Required, TypedDict  # noqa: UP035
 
 import sqlalchemy as sa
 import sqlalchemy.exc as sa_exc
@@ -675,7 +675,7 @@ class AsyncSQLAdapter(AsyncAdapterBase, AsyncAdapter[T]):
         adapt_kw: dict | None = None,
         validation_errors: tuple[type[Exception], ...] = (PydanticValidationError,),
         **kw,
-    ) -> T | list[T]:
+    ) -> T | list[T] | dict[str, Any] | None:
         try:
             # Get operation type (default: "select" for backward compatibility)
             operation = obj.get("operation", "select").lower()

--- a/src/pydapter/extras/mongo_.py
+++ b/src/pydapter/extras/mongo_.py
@@ -131,7 +131,7 @@ class MongoAdapter(AdapterBase, Adapter[T]):
             if obj is not None:
                 if "url" not in obj:
                     raise AdapterValidationError("Missing required parameter 'url'", data=obj)
-                if "db" not in obj:
+                if "db" not in obj and "database" not in obj:
                     raise AdapterValidationError("Missing required parameter 'db'", data=obj)
                 if "collection" not in obj:
                     raise AdapterValidationError(
@@ -141,7 +141,7 @@ class MongoAdapter(AdapterBase, Adapter[T]):
             else:
                 if not kw.get("url"):
                     raise AdapterValidationError("Missing required parameter 'url'")
-                if not kw.get("db"):
+                if not (kw.get("db") or kw.get("database")):
                     raise AdapterValidationError("Missing required parameter 'db'")
                 if not kw.get("collection"):
                     raise AdapterValidationError("Missing required parameter 'collection'")
@@ -404,17 +404,16 @@ class MongoAdapter(AdapterBase, Adapter[T]):
             cls._validate_connection(client)
 
             # Get collection and validate filter
-            coll = cls._get_collection(client, obj["db"], obj["collection"])
+            db = obj.get("db") or obj.get("database")
+            coll = cls._get_collection(client, db, obj["collection"])
             filter_query = cls._validate_filter(obj.get("filter"))
 
             # Execute query
-            docs = cls._execute_find(coll, filter_query, obj["url"], obj["db"], obj["collection"])
+            docs = cls._execute_find(coll, filter_query, obj["url"], db, obj["collection"])
 
             # Handle empty results
             if not docs:
-                return cls._handle_empty_result(
-                    many, f"{obj['db']}.{obj['collection']}", filter_query
-                )
+                return cls._handle_empty_result(many, f"{db}.{obj['collection']}", filter_query)
 
             # Convert documents to models
             return cls._convert_documents(
@@ -436,7 +435,7 @@ class MongoAdapter(AdapterBase, Adapter[T]):
         /,
         *,
         url: str,
-        db: str,
+        db: str | None = None,
         collection: str,
         many: bool = True,
         adapt_meth: str | Callable = "model_dump",
@@ -445,6 +444,7 @@ class MongoAdapter(AdapterBase, Adapter[T]):
     ) -> dict | None:
         try:
             # Validate parameters
+            db = db or kw.get("database")
             cls._validate_params(None, url=url, db=db, collection=collection)
 
             # Create and validate client

--- a/src/pydapter/extras/qdrant_.py
+++ b/src/pydapter/extras/qdrant_.py
@@ -137,7 +137,7 @@ class QdrantAdapter(AdapterBase, Adapter[T]):
         subj: T | Sequence[T],
         /,
         *,
-        collection,
+        collection=None,
         vector_field="embedding",
         id_field="id",
         url=None,
@@ -149,6 +149,7 @@ class QdrantAdapter(AdapterBase, Adapter[T]):
     ) -> dict | None:
         try:
             # Validate required parameters
+            collection = collection or kw.get("collection_name")
             if not collection:
                 raise AdapterValidationError("Missing required parameter 'collection'")
 
@@ -282,7 +283,8 @@ class QdrantAdapter(AdapterBase, Adapter[T]):
     ) -> T | list[T]:
         try:
             # Validate required parameters
-            if "collection" not in obj:
+            collection = obj.get("collection") or obj.get("collection_name")
+            if not collection:
                 raise AdapterValidationError("Missing required parameter 'collection'", data=obj)
             if "query_vector" not in obj:
                 raise AdapterValidationError("Missing required parameter 'query_vector'", data=obj)
@@ -297,7 +299,7 @@ class QdrantAdapter(AdapterBase, Adapter[T]):
             try:
                 # Set a high score threshold to ensure we get enough results
                 res = client.search(
-                    obj["collection"],
+                    collection,
                     obj["query_vector"],
                     limit=obj.get("top_k", 5),
                     with_payload=True,
@@ -307,7 +309,7 @@ class QdrantAdapter(AdapterBase, Adapter[T]):
                 if "not found" in str(e).lower():
                     raise ResourceError(
                         f"Qdrant collection not found: {e}",
-                        resource=obj["collection"],
+                        resource=collection,
                     ) from e
                 raise QueryError(
                     f"Failed to search Qdrant: {e}",
@@ -334,7 +336,7 @@ class QdrantAdapter(AdapterBase, Adapter[T]):
                     return []
                 raise ResourceError(
                     "No points found matching the query vector",
-                    resource=obj["collection"],
+                    resource=collection,
                 )
 
             # Convert documents to model instances using dispatch_adapt_meth

--- a/src/pydapter/migrations/__init__.py
+++ b/src/pydapter/migrations/__init__.py
@@ -59,11 +59,9 @@ __all__ = [
 # Optional imports based on available dependencies
 if find_spec("sqlalchemy") is not None and find_spec("alembic") is not None:
     try:
-        from .sql.alembic_adapter import (  # noqa: F401
-            AlembicAdapter,
-            AsyncAlembicAdapter,
-        )
+        from .sql.alembic_adapter import AlembicAdapter  # noqa: F401
 
-        __all__.extend(["AlembicAdapter", "AsyncAlembicAdapter"])
+        # AsyncAlembicAdapter is incomplete; keep it unexported until implemented.
+        __all__.extend(["AlembicAdapter"])
     except ImportError:
         pass

--- a/src/pydapter/migrations/registry.py
+++ b/src/pydapter/migrations/registry.py
@@ -22,6 +22,7 @@ class MigrationRegistry:
 
     def __init__(self) -> None:
         self._reg: dict[str, type[MigrationProtocol]] = {}
+        self._instances: dict[str, Any] = {}
 
     def register(self, adapter_cls: type[MigrationProtocol]) -> None:
         """
@@ -78,7 +79,9 @@ class MigrationRegistry:
         """
         try:
             adapter_cls = self.get(migration_key)
-            adapter_cls.init_migrations(directory, **kwargs)
+            adapter = adapter_cls.init_migrations(directory, **kwargs)
+            if adapter is not None:
+                self._instances[migration_key] = adapter
         except Exception as exc:
             if isinstance(exc, MigrationError):
                 raise
@@ -108,8 +111,8 @@ class MigrationRegistry:
             MigrationCreationError: If creation fails
         """
         try:
-            adapter_cls = self.get(migration_key)
-            return adapter_cls.create_migration(message, autogenerate, **kwargs)
+            adapter = self._instances.get(migration_key) or self.get(migration_key)
+            return adapter.create_migration(message, autogenerate, **kwargs)
         except Exception as exc:
             if isinstance(exc, MigrationError):
                 raise
@@ -134,8 +137,8 @@ class MigrationRegistry:
             MigrationUpgradeError: If upgrade fails
         """
         try:
-            adapter_cls = self.get(migration_key)
-            adapter_cls.upgrade(revision, **kwargs)
+            adapter = self._instances.get(migration_key) or self.get(migration_key)
+            adapter.upgrade(revision, **kwargs)
         except Exception as exc:
             if isinstance(exc, MigrationError):
                 raise
@@ -159,8 +162,8 @@ class MigrationRegistry:
             MigrationDowngradeError: If downgrade fails
         """
         try:
-            adapter_cls = self.get(migration_key)
-            adapter_cls.downgrade(revision, **kwargs)
+            adapter = self._instances.get(migration_key) or self.get(migration_key)
+            adapter.downgrade(revision, **kwargs)
         except Exception as exc:
             if isinstance(exc, MigrationError):
                 raise
@@ -186,8 +189,8 @@ class MigrationRegistry:
             MigrationError: If getting the current revision fails
         """
         try:
-            adapter_cls = self.get(migration_key)
-            return adapter_cls.get_current_revision(**kwargs)
+            adapter = self._instances.get(migration_key) or self.get(migration_key)
+            return adapter.get_current_revision(**kwargs)
         except Exception as exc:
             if isinstance(exc, MigrationError):
                 raise
@@ -212,8 +215,8 @@ class MigrationRegistry:
             MigrationError: If getting the migration history fails
         """
         try:
-            adapter_cls = self.get(migration_key)
-            return adapter_cls.get_migration_history(**kwargs)
+            adapter = self._instances.get(migration_key) or self.get(migration_key)
+            return adapter.get_migration_history(**kwargs)
         except Exception as exc:
             if isinstance(exc, MigrationError):
                 raise

--- a/src/pydapter/model_adapters/pg_vector_model.py
+++ b/src/pydapter/model_adapters/pg_vector_model.py
@@ -39,7 +39,9 @@ class PGVectorModelAdapter(SQLModelAdapter):
 
         for col in mapper.columns:
             if isinstance(col.type, Vector):
-                py_type = list[float] | (None if col.nullable else Any)
+                py_type = list[float]
+                if col.nullable:
+                    py_type = py_type | None
                 extra = {"vector_dim": col.type.dim}
                 default_val = None if col.nullable else ...
                 fields[col.key] = (

--- a/uv.lock
+++ b/uv.lock
@@ -2747,6 +2747,7 @@ all = [
     { name = "asyncpg" },
     { name = "email-validator" },
     { name = "greenlet" },
+    { name = "grpcio" },
     { name = "motor" },
     { name = "neo4j" },
     { name = "openpyxl" },
@@ -2799,6 +2800,7 @@ migrations-sql = [
     { name = "sqlalchemy", extra = ["asyncio"] },
 ]
 mongo = [
+    { name = "motor" },
     { name = "pymongo" },
 ]
 motor = [
@@ -2830,6 +2832,7 @@ postgres = [
     { name = "sqlalchemy", extra = ["asyncio"] },
 ]
 qdrant = [
+    { name = "grpcio" },
     { name = "qdrant-client", version = "1.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
     { name = "qdrant-client", version = "1.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
 ]
@@ -2866,6 +2869,7 @@ utils = [
     { name = "python-dotenv" },
 ]
 weaviate = [
+    { name = "aiohttp" },
     { name = "weaviate" },
     { name = "weaviate-client" },
 ]
@@ -2892,6 +2896,7 @@ requires-dist = [
     { name = "factory-boy", marker = "extra == 'test'", specifier = ">=3.3.0" },
     { name = "faker", marker = "extra == 'test'", specifier = ">=37.3.0" },
     { name = "greenlet", marker = "extra == 'postgres'", specifier = ">=3.0.0" },
+    { name = "grpcio", marker = "extra == 'qdrant'", specifier = ">=1.60" },
     { name = "hypothesis", marker = "extra == 'test'", specifier = ">=6.130.0" },
     { name = "hypothesis-jsonschema", marker = "extra == 'test'", specifier = ">=0.23.0" },
     { name = "ipykernel", marker = "extra == 'utils'", specifier = ">=6.0.0" },
@@ -2917,6 +2922,7 @@ requires-dist = [
     { name = "py-spy", marker = "extra == 'performance'", specifier = ">=0.4.0" },
     { name = "pydantic", specifier = ">=2.6" },
     { name = "pydapter", extras = ["aiohttp"], marker = "extra == 'all'" },
+    { name = "pydapter", extras = ["aiohttp"], marker = "extra == 'weaviate'" },
     { name = "pydapter", extras = ["aiosqlite"], marker = "extra == 'all'" },
     { name = "pydapter", extras = ["email"], marker = "extra == 'all'" },
     { name = "pydapter", extras = ["excel"], marker = "extra == 'all'" },
@@ -2924,6 +2930,7 @@ requires-dist = [
     { name = "pydapter", extras = ["migrations-sql"], marker = "extra == 'migrations'" },
     { name = "pydapter", extras = ["mongo"], marker = "extra == 'all'" },
     { name = "pydapter", extras = ["motor"], marker = "extra == 'all'" },
+    { name = "pydapter", extras = ["motor"], marker = "extra == 'mongo'" },
     { name = "pydapter", extras = ["neo4j"], marker = "extra == 'all'" },
     { name = "pydapter", extras = ["pandas"], marker = "extra == 'excel'" },
     { name = "pydapter", extras = ["pgvector"], marker = "extra == 'all'" },


### PR DESCRIPTION
## Summary

Resolves all CRITICAL and HIGH findings from the v1.3.1 architecture audit.

- **CRITICAL**: MigrationRegistry called instance methods as classmethods — runtime crash on `create_migration()`
- **CRITICAL**: AsyncAlembicAdapter exported but unimplemented (NotImplementedError) — removed from exports
- **HIGH**: pg_vector non-nullable vectors typed `list[float] | Any` → `list[float]`
- **HIGH**: AsyncSQLAdapter return type mismatch on delete/raw SQL
- **HIGH**: Missing dependency declarations (grpcio for qdrant, aiohttp for weaviate, motor for mongo)
- **HIGH**: Adapter TypeVar variance incorrect (contravariant in return position)
- **HIGH**: Mongo/Qdrant docstring examples use wrong param names — added aliases

## Test plan

- [x] 641 tests pass, 0 regressions
- [x] 3 pre-existing Docker errors (no daemon) — unrelated
- [x] Critic gate: APPROVE-WITH-FIXES → round 2 patched 2 minors → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)